### PR TITLE
Update Tic Tac Toe to receive/send our web API JSON format

### DIFF
--- a/cli/.idea/vcs.xml
+++ b/cli/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/cli/.idea/vcs.xml
+++ b/cli/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
-  </component>
-</project>

--- a/cli/src/main/java/com/github/martingaston/tictactoe/Main.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/Main.java
@@ -1,5 +1,6 @@
 package com.github.martingaston.tictactoe;
 
+import com.github.martingaston.tictactoe.cli.Game;
 import com.github.martingaston.tictactoe.cli.IO;
 import com.github.martingaston.tictactoe.state.State;
 import com.github.martingaston.tictactoe.state.StateCLI;

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
@@ -1,0 +1,23 @@
+package com.github.martingaston.tictactoe.api;
+
+import com.github.martingaston.tictactoe.Messages;
+
+import java.util.*;
+
+public class API {
+    public String init() {
+        boolean isActive = true;
+
+        List<String> Board = new ArrayList<>(Arrays.asList(null, null, null, null, null, null, null, null, null));
+
+        Map<String, String> messages = new HashMap<>();
+        messages.put("title", "TIC TAC TOE");
+        messages.put("intro", Messages.getIntro());
+        messages.put("instructions", Messages.getInstructions(3));
+        messages.put("turn", "Player X's turn");
+
+        String currentPlayer = "X";
+
+        return "X";
+    }
+}

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
@@ -1,14 +1,14 @@
 package com.github.martingaston.tictactoe.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.martingaston.tictactoe.Messages;
+import com.github.martingaston.tictactoe.board.Symbol;
 
 import java.util.*;
 
 public class API {
-    public String init() {
-        boolean isActive = true;
-
-        List<String> Board = new ArrayList<>(Arrays.asList(null, null, null, null, null, null, null, null, null));
+    public static String init() {
+        List<String> board = new ArrayList<>(Arrays.asList(null, null, null, null, null, null, null, null, null));
 
         Map<String, String> messages = new HashMap<>();
         messages.put("title", "TIC TAC TOE");
@@ -16,8 +16,21 @@ public class API {
         messages.put("instructions", Messages.getInstructions(3));
         messages.put("turn", "Player X's turn");
 
-        String currentPlayer = "X";
+        Symbol currentPlayer = new Symbol("X");
+        String mode = "ai";
 
-        return "X";
+        var gameJson = new GameJSON.Builder()
+                .isActive(true)
+                .board(board)
+                .messages(messages)
+                .currentPlayer(currentPlayer)
+                .mode(mode)
+                .build();
+
+        try {
+            return Encode.from(gameJson);
+        } catch (JsonProcessingException error) {
+            return "{}";
+        }
     }
 }

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
@@ -9,6 +9,10 @@ import java.util.*;
 
 public class API {
     public static String init() {
+        return API.init("ai");
+    }
+
+    public static String init(String mode) {
         List<String> board = new ArrayList<>(Arrays.asList(null, null, null, null, null, null, null, null, null));
 
         Map<String, String> messages = new HashMap<>();
@@ -18,7 +22,6 @@ public class API {
         messages.put("turn", "Player X's turn");
 
         Symbol currentPlayer = new Symbol("X");
-        String mode = "ai";
 
         var gameJson = new GameJSON.Builder()
                 .isActive(true)

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
@@ -1,41 +1,14 @@
 package com.github.martingaston.tictactoe.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.github.martingaston.tictactoe.Messages;
-import com.github.martingaston.tictactoe.board.Symbol;
-
 import java.io.IOException;
-import java.util.*;
 
 public class API {
-    public static String init() {
+    public static String init() throws IOException {
         return API.init("ai");
     }
 
-    public static String init(String mode) {
-        List<String> board = new ArrayList<>(Arrays.asList(null, null, null, null, null, null, null, null, null));
-
-        Map<String, String> messages = new HashMap<>();
-        messages.put("title", "TIC TAC TOE");
-        messages.put("intro", Messages.getIntro());
-        messages.put("instructions", Messages.getInstructions(3));
-        messages.put("turn", "Player X's turn");
-
-        Symbol currentPlayer = new Symbol("X");
-
-        var gameJson = new GameJSON.Builder()
-                .isActive(true)
-                .board(board)
-                .messages(messages)
-                .currentPlayer(currentPlayer)
-                .mode(mode)
-                .build();
-
-        try {
-            return Encode.from(gameJson);
-        } catch (JsonProcessingException error) {
-            return "{}";
-        }
+    public static String init(String mode) throws IOException {
+        return Encode.from(Response.initial(mode));
     }
 
     public static String update(int position, String jsonString) throws IOException {

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/API.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.martingaston.tictactoe.Messages;
 import com.github.martingaston.tictactoe.board.Symbol;
 
+import java.io.IOException;
 import java.util.*;
 
 public class API {
@@ -32,5 +33,11 @@ public class API {
         } catch (JsonProcessingException error) {
             return "{}";
         }
+    }
+
+    public static String update(int position, String jsonString) throws IOException {
+        GameJSON previousGame = Decode.from(jsonString);
+        GameJSON updated = Update.from(position, previousGame);
+        return Encode.from(updated);
     }
 }

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Decode.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Decode.java
@@ -3,8 +3,8 @@ package com.github.martingaston.tictactoe.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 
-public class Decode {
-    public static GameJSON from(String game) throws IOException {
+class Decode {
+    static GameJSON from(String game) throws IOException {
         var objectMapper = new ObjectMapper();
         return objectMapper.readValue(game, GameJSON.class);
     }

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Encode.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Encode.java
@@ -3,13 +3,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class Encode {
-    public static String from(GameJSON gameJson) throws JsonProcessingException {
+class Encode {
+    static String from(GameJSON gameJson) throws JsonProcessingException {
         var mapper = new ObjectMapper();
         mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         return mapper.writeValueAsString(gameJson);
     }
-
-
 }
 

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Encode.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Encode.java
@@ -9,5 +9,7 @@ public class Encode {
         mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         return mapper.writeValueAsString(gameJson);
     }
+
+
 }
 

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/GameJSON.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/GameJSON.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class GameJSON {
     private final String mode;
-    private final String currentPlayer;
+    private final Symbol currentPlayer;
     private boolean isActive;
     private List<String> board;
     private Map<String, String> messages;
@@ -24,10 +24,10 @@ public class GameJSON {
             @JsonProperty("board") ArrayList<String> board,
             @JsonProperty("messages") HashMap<String, String> messages
     ) {
-        return new GameJSON(mode, currentPlayer, isActive, board, messages);
+        return new GameJSON(mode, new Symbol(currentPlayer), isActive, board, messages);
     }
 
-    private GameJSON(String mode, String currentPlayer, boolean isActive, List<String> board, Map<String, String> messages) {
+    private GameJSON(String mode, Symbol currentPlayer, boolean isActive, List<String> board, Map<String, String> messages) {
         this.mode = mode;
         this.currentPlayer = currentPlayer;
         this.isActive = isActive;
@@ -73,7 +73,7 @@ public class GameJSON {
         }
 
         public GameJSON build() {
-            return new GameJSON(this.mode, this.currentPlayer.toString(), this.isActive, this.board, this.messages);
+            return new GameJSON(this.mode, this.currentPlayer, this.isActive, this.board, this.messages);
         }
     }
 
@@ -88,7 +88,11 @@ public class GameJSON {
     }
 
     @JsonProperty("currentPlayer")
-    public String currentPlayer() {
+    private String currentPlayerString() {
+        return this.currentPlayer.toString();
+    }
+
+    public Symbol currentPlayer() {
         return this.currentPlayer;
     }
 

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/GameJSON.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/GameJSON.java
@@ -17,7 +17,7 @@ public class GameJSON {
     private Map<String, String> messages;
 
     @JsonCreator
-    public static GameJSON from(
+    private static GameJSON from(
             @JsonProperty("mode") String mode,
             @JsonProperty("currentPlayer") String currentPlayer,
             @JsonProperty("isActive") boolean isActive,

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/GameJSON.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/GameJSON.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class GameJSON {
+class GameJSON {
     private final String mode;
     private final Symbol currentPlayer;
     private boolean isActive;

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Referee.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Referee.java
@@ -14,7 +14,11 @@ class Referee {
         return currentPlayer.equals(new Symbol("X")) ? new Symbol("O") : new Symbol("X");
     }
 
-    static boolean nextPlayerIsNought(Symbol currentPlayer) {
+    static boolean aiShouldMakeMove(GameJSON previousMove) {
+        return previousMove.mode().equals("ai") && Referee.nextPlayerIsNought(previousMove.currentPlayer());
+    }
+
+    private static boolean nextPlayerIsNought(Symbol currentPlayer) {
         return Referee.swapPlayer(currentPlayer).equals(new Symbol("O"));
     }
 

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Referee.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Referee.java
@@ -1,0 +1,44 @@
+package com.github.martingaston.tictactoe.api;
+
+import com.github.martingaston.tictactoe.Messages;
+import com.github.martingaston.tictactoe.board.Board;
+import com.github.martingaston.tictactoe.board.Symbol;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class Referee {
+    static Symbol swapPlayer(Symbol currentPlayer) {
+        return currentPlayer.equals(new Symbol("X")) ? new Symbol("O") : new Symbol("X");
+    }
+
+    static boolean nextPlayerIsNought(Symbol currentPlayer) {
+        return Referee.swapPlayer(currentPlayer).equals(new Symbol("O"));
+    }
+
+    static List<String> formatBoard(Board nextBoard) {
+        return nextBoard
+                .toList()
+                .stream()
+                .map(cell -> cell.equals(" ") ? null : cell)
+                .collect(Collectors.toList());
+    }
+
+    static Map<String, String> getEndingMessage(Board board, Symbol currentPlayer) {
+        var messages = new HashMap<String, String>();
+
+        if(board.hasWon(currentPlayer)) {
+            messages.put("ending", String.format("Player %s wins!", currentPlayer.toString()));
+        } else {
+            messages.put("ending", Messages.playersDraw());
+        }
+
+        return messages;
+    }
+
+    static boolean gameIsActive(Board board) {
+        return !board.isGameOver();
+    }
+}

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Response.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Response.java
@@ -1,0 +1,47 @@
+package com.github.martingaston.tictactoe.api;
+
+import com.github.martingaston.tictactoe.Messages;
+import com.github.martingaston.tictactoe.board.Board;
+import com.github.martingaston.tictactoe.board.Symbol;
+
+import java.util.*;
+
+class Response {
+    static GameJSON initial(String mode) {
+        List<String> board = new ArrayList<>(Arrays.asList(null, null, null, null, null, null, null, null, null));
+
+        Map<String, String> messages = new HashMap<>();
+        messages.put("title", "TIC TAC TOE");
+        messages.put("intro", Messages.getIntro());
+        messages.put("instructions", Messages.getInstructions(3));
+        messages.put("turn", "Player X's turn");
+
+        Symbol currentPlayer = new Symbol("X");
+
+        return new GameJSON.Builder()
+                .isActive(true)
+                .board(board)
+                .messages(messages)
+                .currentPlayer(currentPlayer)
+                .mode(mode)
+                .build();
+    }
+
+    static GameJSON updatedMove(GameJSON previousMove, Board nextBoard) {
+        return new GameJSON.Builder()
+                .isActive(Referee.gameIsActive(nextBoard))
+                .board(Referee.formatBoard(nextBoard))
+                .currentPlayer(Referee.swapPlayer(previousMove.currentPlayer()))
+                .messages(previousMove.messages())
+                .mode(previousMove.mode())
+                .build();
+    }
+
+    static GameJSON gameOver(Board board, Symbol currentPlayer) {
+        return new GameJSON.Builder()
+                .isActive(false)
+                .board(Referee.formatBoard(board))
+                .messages(Referee.getEndingMessage(board, currentPlayer))
+                .build();
+    }
+}

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
@@ -1,35 +1,77 @@
 package com.github.martingaston.tictactoe.api;
 
+import com.github.martingaston.tictactoe.Messages;
+import com.github.martingaston.tictactoe.Minimax;
 import com.github.martingaston.tictactoe.board.Board;
 import com.github.martingaston.tictactoe.board.PopulatedBoard;
 import com.github.martingaston.tictactoe.board.Symbol;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class Update {
     static GameJSON from(int position, GameJSON previousMove) {
-
        Board nextBoard = PopulatedBoard.from(previousMove.board(), new Symbol("X"), new Symbol("O"));
        nextBoard.add(oneIndexedToZeroIndexed(position), previousMove.currentPlayer());
 
-       List<String> returnedBoard = nextBoard
-               .toList()
-               .stream()
-               .map(cell -> cell.equals(" ") ? null : cell)
-               .collect(Collectors.toList());
+       if (nextBoard.isGameOver()) {
+           return gameOver(nextBoard, previousMove.currentPlayer());
+       }
 
-       return new GameJSON.Builder()
-               .isActive(!nextBoard.isGameOver())
-               .board(returnedBoard)
-               .currentPlayer(swapPlayer(previousMove.currentPlayer()))
-               .messages(previousMove.messages())
-               .mode(previousMove.mode())
-               .build();
+       if (nextPlayerIsNought(previousMove.currentPlayer())) {
+           int cpuMove = new Minimax(nextBoard, new Symbol("O"), new Symbol("X")).optimal();
+           return Update.from(cpuMove, updatedGameJson(previousMove, nextBoard));
+       }
+
+        return updatedGameJson(previousMove, nextBoard);
+    }
+
+    private static List<String> formatBoard(Board nextBoard) {
+        return nextBoard
+                   .toList()
+                   .stream()
+                   .map(cell -> cell.equals(" ") ? null : cell)
+                   .collect(Collectors.toList());
+    }
+
+    private static GameJSON updatedGameJson(GameJSON previousMove, Board nextBoard) {
+        return new GameJSON.Builder()
+                .isActive(!nextBoard.isGameOver())
+                .board(formatBoard(nextBoard))
+                .currentPlayer(swapPlayer(previousMove.currentPlayer()))
+                .messages(previousMove.messages())
+                .mode(previousMove.mode())
+                .build();
+    }
+
+    private static GameJSON gameOver(Board board, Symbol currentPlayer) {
+        return new GameJSON.Builder()
+                .isActive(false)
+                .board(formatBoard(board))
+                .messages(getEndingMessage(board, currentPlayer))
+                .build();
     }
 
     private static Symbol swapPlayer(Symbol currentPlayer) {
         return currentPlayer.equals(new Symbol("X")) ? new Symbol("O") : new Symbol("X");
+    }
+
+    private static boolean nextPlayerIsNought(Symbol currentPlayer) {
+        return swapPlayer(currentPlayer).equals(new Symbol("O"));
+    }
+
+    private static Map<String, String> getEndingMessage(Board board, Symbol currentPlayer) {
+        var messages = new HashMap<String, String>();
+
+        if(board.hasWon(currentPlayer)) {
+            messages.put("ending", String.format("Player %s wins!", currentPlayer.toString()));
+        } else {
+            messages.put("ending", Messages.playersDraw());
+        }
+
+        return messages;
     }
 
     private static int oneIndexedToZeroIndexed(int i) {

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
@@ -5,7 +5,7 @@ import com.github.martingaston.tictactoe.board.Board;
 import com.github.martingaston.tictactoe.board.PopulatedBoard;
 import com.github.martingaston.tictactoe.board.Symbol;
 
-public class Update {
+class Update {
     static GameJSON from(int position, GameJSON previousMove) {
        Board nextBoard = PopulatedBoard.from(previousMove.board(), new Symbol("X"), new Symbol("O"));
        nextBoard.add(oneIndexedToZeroIndexed(position), previousMove.currentPlayer());

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
@@ -4,16 +4,14 @@ import com.github.martingaston.tictactoe.board.Board;
 import com.github.martingaston.tictactoe.board.PopulatedBoard;
 import com.github.martingaston.tictactoe.board.Symbol;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class Update {
-    public static GameJSON fromJson(int position, String jsonString) throws IOException {
-       GameJSON previousMove = Decode.from(jsonString);
+    static GameJSON from(int position, GameJSON previousMove) {
 
        Board nextBoard = PopulatedBoard.from(previousMove.board(), new Symbol("X"), new Symbol("O"));
-       nextBoard.add(position - 1, previousMove.currentPlayer());
+       nextBoard.add(oneIndexedToZeroIndexed(position), previousMove.currentPlayer());
 
        List<String> returnedBoard = nextBoard
                .toList()
@@ -22,7 +20,7 @@ public class Update {
                .collect(Collectors.toList());
 
        return new GameJSON.Builder()
-               .isActive(true)
+               .isActive(!nextBoard.isGameOver())
                .board(returnedBoard)
                .currentPlayer(swapPlayer(previousMove.currentPlayer()))
                .messages(previousMove.messages())
@@ -32,5 +30,9 @@ public class Update {
 
     private static Symbol swapPlayer(Symbol currentPlayer) {
         return currentPlayer.equals(new Symbol("X")) ? new Symbol("O") : new Symbol("X");
+    }
+
+    private static int oneIndexedToZeroIndexed(int i) {
+        return i - 1;
     }
 }

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
@@ -1,0 +1,36 @@
+package com.github.martingaston.tictactoe.api;
+
+import com.github.martingaston.tictactoe.board.Board;
+import com.github.martingaston.tictactoe.board.PopulatedBoard;
+import com.github.martingaston.tictactoe.board.Symbol;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Update {
+    public static GameJSON fromJson(int position, String jsonString) throws IOException {
+       GameJSON previousMove = Decode.from(jsonString);
+
+       Board nextBoard = PopulatedBoard.from(previousMove.board(), new Symbol("X"), new Symbol("O"));
+       nextBoard.add(position - 1, previousMove.currentPlayer());
+
+       List<String> returnedBoard = nextBoard
+               .toList()
+               .stream()
+               .map(cell -> cell.equals(" ") ? null : cell)
+               .collect(Collectors.toList());
+
+       return new GameJSON.Builder()
+               .isActive(true)
+               .board(returnedBoard)
+               .currentPlayer(swapPlayer(previousMove.currentPlayer()))
+               .messages(previousMove.messages())
+               .mode(previousMove.mode())
+               .build();
+    }
+
+    private static Symbol swapPlayer(Symbol currentPlayer) {
+        return currentPlayer.equals(new Symbol("X")) ? new Symbol("O") : new Symbol("X");
+    }
+}

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
@@ -14,7 +14,7 @@ public class Update {
            return gameOver(nextBoard, previousMove.currentPlayer());
        }
 
-       if (aiShouldMakeMove(previousMove)) {
+       if (Referee.aiShouldMakeMove(previousMove)) {
            int cpuMove = new Minimax(nextBoard, new Symbol("O"), new Symbol("X")).optimal();
            return Update.from(cpuMove, updatedGameJson(previousMove, nextBoard));
        }
@@ -29,10 +29,6 @@ public class Update {
     private static GameJSON gameOver(Board board, Symbol currentPlayer) {
         return Response.gameOver(board, currentPlayer);
 
-    }
-
-    private static boolean aiShouldMakeMove(GameJSON previousMove) {
-        return previousMove.mode().equals("ai") && Referee.nextPlayerIsNought(previousMove.currentPlayer());
     }
 
     private static int oneIndexedToZeroIndexed(int i) {

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
@@ -1,22 +1,16 @@
 package com.github.martingaston.tictactoe.api;
 
-import com.github.martingaston.tictactoe.Messages;
 import com.github.martingaston.tictactoe.Minimax;
 import com.github.martingaston.tictactoe.board.Board;
 import com.github.martingaston.tictactoe.board.PopulatedBoard;
 import com.github.martingaston.tictactoe.board.Symbol;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class Update {
     static GameJSON from(int position, GameJSON previousMove) {
        Board nextBoard = PopulatedBoard.from(previousMove.board(), new Symbol("X"), new Symbol("O"));
        nextBoard.add(oneIndexedToZeroIndexed(position), previousMove.currentPlayer());
 
-       if (gameIsOver(nextBoard)) {
+       if (nextBoard.isGameOver()) {
            return gameOver(nextBoard, previousMove.currentPlayer());
        }
 
@@ -25,65 +19,20 @@ public class Update {
            return Update.from(cpuMove, updatedGameJson(previousMove, nextBoard));
        }
 
-        return updatedGameJson(previousMove, nextBoard);
-    }
-
-    private static List<String> formatBoard(Board nextBoard) {
-        return nextBoard
-                   .toList()
-                   .stream()
-                   .map(cell -> cell.equals(" ") ? null : cell)
-                   .collect(Collectors.toList());
+       return updatedGameJson(previousMove, nextBoard);
     }
 
     private static GameJSON updatedGameJson(GameJSON previousMove, Board nextBoard) {
-        return new GameJSON.Builder()
-                .isActive(gameIsActive(nextBoard))
-                .board(formatBoard(nextBoard))
-                .currentPlayer(swapPlayer(previousMove.currentPlayer()))
-                .messages(previousMove.messages())
-                .mode(previousMove.mode())
-                .build();
-    }
-
-    private static boolean gameIsActive(Board board) {
-        return !gameIsOver(board);
-    }
-
-    private static boolean gameIsOver(Board board) {
-        return board.isGameOver();
+        return Response.updatedMove(previousMove, nextBoard);
     }
 
     private static GameJSON gameOver(Board board, Symbol currentPlayer) {
-        return new GameJSON.Builder()
-                .isActive(false)
-                .board(formatBoard(board))
-                .messages(getEndingMessage(board, currentPlayer))
-                .build();
-    }
+        return Response.gameOver(board, currentPlayer);
 
-    private static Symbol swapPlayer(Symbol currentPlayer) {
-        return currentPlayer.equals(new Symbol("X")) ? new Symbol("O") : new Symbol("X");
     }
 
     private static boolean aiShouldMakeMove(GameJSON previousMove) {
-        return previousMove.mode().equals("ai") && nextPlayerIsNought(previousMove.currentPlayer());
-    }
-
-    private static boolean nextPlayerIsNought(Symbol currentPlayer) {
-        return swapPlayer(currentPlayer).equals(new Symbol("O"));
-    }
-
-    private static Map<String, String> getEndingMessage(Board board, Symbol currentPlayer) {
-        var messages = new HashMap<String, String>();
-
-        if(board.hasWon(currentPlayer)) {
-            messages.put("ending", String.format("Player %s wins!", currentPlayer.toString()));
-        } else {
-            messages.put("ending", Messages.playersDraw());
-        }
-
-        return messages;
+        return previousMove.mode().equals("ai") && Referee.nextPlayerIsNought(previousMove.currentPlayer());
     }
 
     private static int oneIndexedToZeroIndexed(int i) {

--- a/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/api/Update.java
@@ -16,11 +16,11 @@ public class Update {
        Board nextBoard = PopulatedBoard.from(previousMove.board(), new Symbol("X"), new Symbol("O"));
        nextBoard.add(oneIndexedToZeroIndexed(position), previousMove.currentPlayer());
 
-       if (nextBoard.isGameOver()) {
+       if (gameIsOver(nextBoard)) {
            return gameOver(nextBoard, previousMove.currentPlayer());
        }
 
-       if (nextPlayerIsNought(previousMove.currentPlayer())) {
+       if (aiShouldMakeMove(previousMove)) {
            int cpuMove = new Minimax(nextBoard, new Symbol("O"), new Symbol("X")).optimal();
            return Update.from(cpuMove, updatedGameJson(previousMove, nextBoard));
        }
@@ -38,12 +38,20 @@ public class Update {
 
     private static GameJSON updatedGameJson(GameJSON previousMove, Board nextBoard) {
         return new GameJSON.Builder()
-                .isActive(!nextBoard.isGameOver())
+                .isActive(gameIsActive(nextBoard))
                 .board(formatBoard(nextBoard))
                 .currentPlayer(swapPlayer(previousMove.currentPlayer()))
                 .messages(previousMove.messages())
                 .mode(previousMove.mode())
                 .build();
+    }
+
+    private static boolean gameIsActive(Board board) {
+        return !gameIsOver(board);
+    }
+
+    private static boolean gameIsOver(Board board) {
+        return board.isGameOver();
     }
 
     private static GameJSON gameOver(Board board, Symbol currentPlayer) {
@@ -56,6 +64,10 @@ public class Update {
 
     private static Symbol swapPlayer(Symbol currentPlayer) {
         return currentPlayer.equals(new Symbol("X")) ? new Symbol("O") : new Symbol("X");
+    }
+
+    private static boolean aiShouldMakeMove(GameJSON previousMove) {
+        return previousMove.mode().equals("ai") && nextPlayerIsNought(previousMove.currentPlayer());
     }
 
     private static boolean nextPlayerIsNought(Symbol currentPlayer) {

--- a/cli/src/main/java/com/github/martingaston/tictactoe/board/PopulatedBoard.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/board/PopulatedBoard.java
@@ -2,25 +2,47 @@ package com.github.martingaston.tictactoe.board;
 
 import com.github.martingaston.tictactoe.state.State;
 
+import java.util.List;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
+
 public class PopulatedBoard {
     public static Board from(State state) {
-        if (state.contents().size() != 9 && state.contents().size() != 16) {
+        return from(state.contents(), state.players().playerCross().symbol(), state.players().playerNought().symbol());
+    }
+
+    public static Board from(List<String> boardList, Symbol playerCross, Symbol playerNought) {
+        if(boardList.size() != 9 && boardList.size() != 16) {
             return new Board();
         }
 
-        int sideLength = (int) Math.sqrt(state.contents().size());
+        int sideLength = (int) Math.sqrt(boardList.size());
         Board newBoard = new Board(sideLength);
 
-        for (int i = 0; i < state.contents().size(); i++) {
-            Symbol currentSymbol = new Symbol(state.contents().get(i));
-            if (currentSymbol.equals(state.playerCross())) {
-
-                newBoard.add(i, state.players().playerCross().symbol());
-            } else if (currentSymbol.equals(state.playerNought())) {
-                newBoard.add(i, state.players().playerNought().symbol());
-            }
-        }
+        IntStream
+                .range(0, boardList.size())
+                .forEach(checkOccupant(boardList, newBoard, playerCross.toString(), playerNought.toString()));
 
         return newBoard;
+    }
+
+    private static IntConsumer checkOccupant(List<String> boardList, Board newBoard, String playerCross, String playerNought) {
+        return i -> {
+            if(hasValidOccupant(boardList, playerCross, playerNought, i)) {
+               newBoard.add(i, new Symbol(boardList.get(i)));
+            }
+        };
+    }
+
+    private static boolean hasValidOccupant(List<String> boardList, String playerCross, String playerNought, int i) {
+        return positionIsOccupied(boardList, i) && symbolIsValid(boardList, i, playerCross, playerNought);
+    }
+
+    private static boolean positionIsOccupied(List<String> boardList, int i) {
+        return boardList.get(i) != null && !boardList.get(i).isBlank();
+    }
+
+    private static boolean symbolIsValid(List<String> boardList, int i, String playerCross, String playerNought) {
+        return boardList.get(i).equals(playerCross) || boardList.get(i).equals(playerNought);
     }
 }

--- a/cli/src/main/java/com/github/martingaston/tictactoe/cli/Game.java
+++ b/cli/src/main/java/com/github/martingaston/tictactoe/cli/Game.java
@@ -1,7 +1,7 @@
-package com.github.martingaston.tictactoe;
+package com.github.martingaston.tictactoe.cli;
 
+import com.github.martingaston.tictactoe.Messages;
 import com.github.martingaston.tictactoe.board.Board;
-import com.github.martingaston.tictactoe.cli.Display;
 import com.github.martingaston.tictactoe.player.Player;
 import com.github.martingaston.tictactoe.player.Players;
 import com.github.martingaston.tictactoe.state.State;
@@ -9,11 +9,11 @@ import com.github.martingaston.tictactoe.storage.Storage;
 
 import java.io.IOException;
 
-class Game {
+public class Game {
     private static Board board;
     private static Players players;
 
-    static void play(State state, Storage storage) throws IOException {
+    public static void play(State state, Storage storage) throws IOException {
         board = state.board();
         players = state.players();
 

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
@@ -8,15 +8,15 @@ import static org.junit.Assert.*;
 
 public class APITest {
     @Test
-    public void initCreatesRequiredResponse() throws IOException {
-        String result = API.init("ai");
+    public void initWithZeroArgsReturnsAIGame() throws IOException {
+        String result = API.init();
         String expected = "{\"board\":[null,null,null,null,null,null,null,null,null],\"currentPlayer\":\"X\",\"isActive\":true,\"messages\":{\"instructions\":\"Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.\",\"intro\":\"TIC TAC TOE\\nThe classic game of noughts and crosses!\\nTurn friends into enemies as 2 players take turns marking spaces in a grid.\\nWin short-lived glory by succeeding in placing a complete line in any horizontal, vertical or diagonal direction.\\n\",\"turn\":\"Player X's turn\",\"title\":\"TIC TAC TOE\"},\"mode\":\"ai\"}";
 
         assertEquals(expected, result);
     }
 
     @Test
-    public void updateReturnsNewOptions() throws IOException {
+    public void initWithHumanModeReturnsNoughtPlayerMove() throws IOException {
         String moveZero = API.init("human");
         int position = 1;
         String moveOne = API.update(position, moveZero);

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
@@ -13,4 +13,6 @@ public class APITest {
         assertEquals(expected, result);
     }
 
+
+
 }

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
@@ -2,6 +2,8 @@ package com.github.martingaston.tictactoe.api;
 
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.*;
 
 public class APITest {
@@ -11,6 +13,16 @@ public class APITest {
         String expected = "{\"board\":[null,null,null,null,null,null,null,null,null],\"currentPlayer\":\"X\",\"isActive\":true,\"messages\":{\"instructions\":\"Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.\",\"intro\":\"TIC TAC TOE\\nThe classic game of noughts and crosses!\\nTurn friends into enemies as 2 players take turns marking spaces in a grid.\\nWin short-lived glory by succeeding in placing a complete line in any horizontal, vertical or diagonal direction.\\n\",\"turn\":\"Player X's turn\",\"title\":\"TIC TAC TOE\"},\"mode\":\"ai\"}";
 
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void updateReturnsNewOptions() throws IOException {
+        String moveZero = API.init();
+        int position = 1;
+        String moveOne = API.update(position, moveZero);
+        String expected = "{\"board\":[\"X\",null,null,null,null,null,null,null,null],\"currentPlayer\":\"O\",\"isActive\":true,\"messages\":{\"instructions\":\"Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.\",\"intro\":\"TIC TAC TOE\\nThe classic game of noughts and crosses!\\nTurn friends into enemies as 2 players take turns marking spaces in a grid.\\nWin short-lived glory by succeeding in placing a complete line in any horizontal, vertical or diagonal direction.\\n\",\"turn\":\"Player X's turn\",\"title\":\"TIC TAC TOE\"},\"mode\":\"ai\"}";
+
+        assertEquals(expected, moveOne);
     }
 
 

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
@@ -8,8 +8,8 @@ import static org.junit.Assert.*;
 
 public class APITest {
     @Test
-    public void initCreatesRequiredResponse() {
-        String result = API.init();
+    public void initCreatesRequiredResponse() throws IOException {
+        String result = API.init("ai");
         String expected = "{\"board\":[null,null,null,null,null,null,null,null,null],\"currentPlayer\":\"X\",\"isActive\":true,\"messages\":{\"instructions\":\"Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.\",\"intro\":\"TIC TAC TOE\\nThe classic game of noughts and crosses!\\nTurn friends into enemies as 2 players take turns marking spaces in a grid.\\nWin short-lived glory by succeeding in placing a complete line in any horizontal, vertical or diagonal direction.\\n\",\"turn\":\"Player X's turn\",\"title\":\"TIC TAC TOE\"},\"mode\":\"ai\"}";
 
         assertEquals(expected, result);
@@ -17,10 +17,10 @@ public class APITest {
 
     @Test
     public void updateReturnsNewOptions() throws IOException {
-        String moveZero = API.init();
+        String moveZero = API.init("human");
         int position = 1;
         String moveOne = API.update(position, moveZero);
-        String expected = "{\"board\":[\"X\",null,null,null,null,null,null,null,null],\"currentPlayer\":\"O\",\"isActive\":true,\"messages\":{\"instructions\":\"Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.\",\"intro\":\"TIC TAC TOE\\nThe classic game of noughts and crosses!\\nTurn friends into enemies as 2 players take turns marking spaces in a grid.\\nWin short-lived glory by succeeding in placing a complete line in any horizontal, vertical or diagonal direction.\\n\",\"turn\":\"Player X's turn\",\"title\":\"TIC TAC TOE\"},\"mode\":\"ai\"}";
+        String expected = "{\"board\":[\"X\",null,null,null,null,null,null,null,null],\"currentPlayer\":\"O\",\"isActive\":true,\"messages\":{\"instructions\":\"Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.\",\"intro\":\"TIC TAC TOE\\nThe classic game of noughts and crosses!\\nTurn friends into enemies as 2 players take turns marking spaces in a grid.\\nWin short-lived glory by succeeding in placing a complete line in any horizontal, vertical or diagonal direction.\\n\",\"turn\":\"Player X's turn\",\"title\":\"TIC TAC TOE\"},\"mode\":\"human\"}";
 
         assertEquals(expected, moveOne);
     }

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/APITest.java
@@ -1,0 +1,16 @@
+package com.github.martingaston.tictactoe.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class APITest {
+    @Test
+    public void initCreatesRequiredResponse() {
+        String result = API.init();
+        String expected = "{\"board\":[null,null,null,null,null,null,null,null,null],\"currentPlayer\":\"X\",\"isActive\":true,\"messages\":{\"instructions\":\"Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.\",\"intro\":\"TIC TAC TOE\\nThe classic game of noughts and crosses!\\nTurn friends into enemies as 2 players take turns marking spaces in a grid.\\nWin short-lived glory by succeeding in placing a complete line in any horizontal, vertical or diagonal direction.\\n\",\"turn\":\"Player X's turn\",\"title\":\"TIC TAC TOE\"},\"mode\":\"ai\"}";
+
+        assertEquals(expected, result);
+    }
+
+}

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/DecodeTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/DecodeTest.java
@@ -1,5 +1,6 @@
 package com.github.martingaston.tictactoe.api;
 
+import com.github.martingaston.tictactoe.board.Symbol;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class DecodeTest {
     public void hasCurrentPlayer() throws IOException {
         var decoder = Decode.from(game);
 
-        assertEquals("X", decoder.currentPlayer());
+        assertEquals(new Symbol("X"), decoder.currentPlayer());
     }
 
     @Test

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
@@ -1,0 +1,32 @@
+package com.github.martingaston.tictactoe.api;
+
+import com.github.martingaston.tictactoe.board.Symbol;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class UpdateTest {
+    @Test
+    public void updateCanAddMoveToBoard() throws IOException {
+        String init = API.init();
+        int movePosition = 1;
+        GameJSON updatedGame = Update.fromJson(movePosition, init);
+        List<String> expectedBoard = new ArrayList<>(Arrays.asList("X", null, null, null, null, null, null, null, null));
+
+        assertEquals(expectedBoard, updatedGame.board());
+    }
+
+    @Test
+    public void updateWillSwapCurrentPlayer() throws IOException {
+        String init = API.init();
+        int movePosition = 1;
+        GameJSON updatedGame = Update.fromJson(movePosition, init);
+
+        assertEquals(new Symbol("O"), updatedGame.currentPlayer());
+    }
+}

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -47,5 +48,16 @@ public class UpdateTest {
         assertTrue(moveFour.isActive());
         assertFalse(moveFive.isActive());
         assertEquals("Player X wins!", moveFive.messages().get("ending"));
+    }
+
+    @Test
+    public void aiModeTakesNoughtTurns() throws IOException {
+        GameJSON initialGame = Decode.from(API.init("ai"));
+
+        GameJSON moveOne = Update.from(1, initialGame);
+        int movesPlayed = (int) moveOne.board().stream().filter(Objects::nonNull).count();
+
+        assertEquals(moveOne.currentPlayer(), new Symbol("X"));
+        assertEquals(2, movesPlayed);
     }
 }

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
@@ -8,25 +8,43 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class UpdateTest {
     @Test
-    public void updateCanAddMoveToBoard() throws IOException {
-        String init = API.init();
+    public void canAddMoveToBoard() throws IOException {
+        GameJSON game = Decode.from(API.init());
         int movePosition = 1;
-        GameJSON updatedGame = Update.fromJson(movePosition, init);
         List<String> expectedBoard = new ArrayList<>(Arrays.asList("X", null, null, null, null, null, null, null, null));
+
+        GameJSON updatedGame = Update.from(movePosition, game);
 
         assertEquals(expectedBoard, updatedGame.board());
     }
 
     @Test
-    public void updateWillSwapCurrentPlayer() throws IOException {
-        String init = API.init();
+    public void willSwapCurrentPlayer() throws IOException {
+        GameJSON game = Decode.from(API.init());
         int movePosition = 1;
-        GameJSON updatedGame = Update.fromJson(movePosition, init);
+
+        GameJSON updatedGame = Update.from(movePosition, game);
 
         assertEquals(new Symbol("O"), updatedGame.currentPlayer());
+    }
+
+    @Test
+    public void isActiveIsFalseWhenGameIsOver() throws IOException {
+        GameJSON initialGame = Decode.from(API.init());
+
+        GameJSON moveOne = Update.from(1, initialGame);
+        GameJSON moveTwo = Update.from(4, moveOne);
+        GameJSON moveThree = Update.from(2, moveTwo);
+        GameJSON moveFour = Update.from(5, moveThree);
+        GameJSON moveFive = Update.from(3, moveFour);
+
+        assertTrue(moveFour.isActive());
+        assertFalse(moveFive.isActive());
     }
 }

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertFalse;
 public class UpdateTest {
     @Test
     public void canAddMoveToBoard() throws IOException {
-        GameJSON game = Decode.from(API.init());
+        GameJSON game = Decode.from(API.init("human"));
         int movePosition = 1;
         List<String> expectedBoard = new ArrayList<>(Arrays.asList("X", null, null, null, null, null, null, null, null));
 
@@ -26,7 +26,7 @@ public class UpdateTest {
 
     @Test
     public void willSwapCurrentPlayer() throws IOException {
-        GameJSON game = Decode.from(API.init());
+        GameJSON game = Decode.from(API.init("human"));
         int movePosition = 1;
 
         GameJSON updatedGame = Update.from(movePosition, game);
@@ -36,7 +36,7 @@ public class UpdateTest {
 
     @Test
     public void isActiveIsFalseWhenGameIsOver() throws IOException {
-        GameJSON initialGame = Decode.from(API.init());
+        GameJSON initialGame = Decode.from(API.init("human"));
 
         GameJSON moveOne = Update.from(1, initialGame);
         GameJSON moveTwo = Update.from(4, moveOne);

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
@@ -46,5 +46,6 @@ public class UpdateTest {
 
         assertTrue(moveFour.isActive());
         assertFalse(moveFive.isActive());
+        assertEquals("Player X wins!", moveFive.messages().get("ending"));
     }
 }

--- a/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/api/UpdateTest.java
@@ -51,6 +51,19 @@ public class UpdateTest {
     }
 
     @Test
+    public void aDrawReturnsADrawMessage() throws IOException {
+        GameJSON game = Decode.from(API.init("human"));
+        List<Integer> movesList = new ArrayList<>(Arrays.asList(1, 5, 2, 3, 7, 4, 8, 9, 6));
+
+        for (Integer movePosition : movesList) {
+            game = Update.from(movePosition, game);
+        }
+
+        assertFalse(game.isActive());
+        assertEquals("Bad luck! It's a draw!", game.messages().get("ending"));
+    }
+
+    @Test
     public void aiModeTakesNoughtTurns() throws IOException {
         GameJSON initialGame = Decode.from(API.init("ai"));
 

--- a/cli/src/test/java/com/github/martingaston/tictactoe/cli/GameTest.java
+++ b/cli/src/test/java/com/github/martingaston/tictactoe/cli/GameTest.java
@@ -1,5 +1,6 @@
-package com.github.martingaston.tictactoe;
+package com.github.martingaston.tictactoe.cli;
 
+import com.github.martingaston.tictactoe.Main;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
This PR updates our Tic Tac Toe game (`/cli` in our monorepo) to add support for our incoming web API. 

This is a very interesting user story because it involves 1) coming back to a (what now seems like) very long ago project. 2) adding in a set of features that directly clash with the design decisions taken formerly (immutable, single-turn). 

A summary of changes: 

- `Game` has been moved into a `CLI` package to more clearly show its intent
- `PopulatedBoard` has been refactored to work with API while maintaining existing CLI compatibility.
- An `API` package has been sprouted, which handles incoming stringified JSON requests and outputs stringified JSON requests. These requests fit to the shape of the React frontend. 

There are undoubtedly better ways to implement this, most of which would involve a significant refactoring of the existing code. Ideally I would like to totally rethink the interfaces and create an overall `Game` interface that supports better polymorphism. Instead we have a silo'd implementation that likely has some duplication from our existing code, but this is the most efficient solution I could get working in the time that I had 😬 

Next steps: 

- Add the HTTP routes to the server and connect to this API. The HTTP server will not need to serialise/deserialise the JSON, which is neat. 
- Update the frontend to call the backend. 

