### PR TITLE
Sprint1/backend/add cors support

### DIFF
--- a/backend/src/main/java/com/github/martingaston/application/http/Response.java
+++ b/backend/src/main/java/com/github/martingaston/application/http/Response.java
@@ -76,6 +76,7 @@ public class Response {
 
         public Options json(Body body) {
             this.addHeader("Content-Type", "application/json");
+            this.addHeader("Access-Control-Allow-Origin", "*");
             this.body = body;
             return this;
         }

--- a/backend/src/main/java/com/github/martingaston/application/http/Router.java
+++ b/backend/src/main/java/com/github/martingaston/application/http/Router.java
@@ -70,8 +70,23 @@ public class Router {
 
     private static Response sendOptionsResponse(Request request, Response.Options response, Routes routes) {
         response.addHeader("Allow", routes.validAtPath(request));
+
+        if (isACorsRequest(request)) {
+            addCorsPreflightHeaders(request, response, routes);
+        }
+
         response.body(Body.from(""));
         return response.build();
+    }
+
+    private static void addCorsPreflightHeaders(Request request, Response.Options response, Routes routes) {
+        response.addHeader("Access-Control-Allow-Origin", "*");
+        response.addHeader("Access-Control-Allow-Methods", routes.validAtPath(request));
+        response.addHeader("Access-Control-Allow-Headers", "origin, content-type, accept");
+    }
+
+    private static boolean isACorsRequest(Request request) {
+        return request.hasHeader("Access-Control-Request-Method");
     }
 
     private static boolean headRequest(Request request) {

--- a/backend/src/main/java/com/github/martingaston/application/http/Router.java
+++ b/backend/src/main/java/com/github/martingaston/application/http/Router.java
@@ -80,9 +80,9 @@ public class Router {
     }
 
     private static void addCorsPreflightHeaders(Request request, Response.Options response, Routes routes) {
-        response.addHeader("Access-Control-Allow-Origin", "*");
+        response.addHeader("Access-Control-Allow-Origin", request.getHeader("origin"));
         response.addHeader("Access-Control-Allow-Methods", routes.validAtPath(request));
-        response.addHeader("Access-Control-Allow-Headers", "origin, content-type, accept");
+        response.addHeader("Access-Control-Allow-Headers", "accept, accept-language, content-language, content-type, origin");
     }
 
     private static boolean isACorsRequest(Request request) {

--- a/backend/src/test/java/com/github/martingaston/application/http/RouterTest.java
+++ b/backend/src/test/java/com/github/martingaston/application/http/RouterTest.java
@@ -144,6 +144,29 @@ class RouterTest {
         void returnsContentLengthHeader() {
             assertThat(response.headers().get("Allow")).isEqualTo("GET, HEAD, OPTIONS");
         }
+
+        @DisplayName("Does not have CORS headers if not a CORS preflight request")
+        @Test
+        void doesNotHaveCorsHeadersWhenNotCorsRequest() {
+            assertThat(response.headers().contains("Access-Control-Allow-Origin")).isFalse();
+            assertThat(response.headers().contains("Access-Control-Allow-Methods")).isFalse();
+            assertThat(response.headers().contains("Access-Control-Allow-Headers")).isFalse();
+        }
+
+        @DisplayName("Does contains CORS headers when is a CORS request")
+        @Test
+        void doesContainCorsHeadersWhenCorsRequest() throws IOException {
+            Headers corsHeaders = new Headers();
+            corsHeaders.add("Host", "localhost:5000");
+            corsHeaders.add("Access-Control-Request-Method", "GET");
+            var corsRequest = new Request(new RequestLine(Verbs.OPTIONS, URI.from("/method_options"), Version.V1POINT1), corsHeaders, Body.from(""));
+
+            var corsResponse = router.respond(corsRequest);
+
+            assertThat(corsResponse.headers().contains("Access-Control-Allow-Origin")).isTrue();
+            assertThat(corsResponse.headers().contains("Access-Control-Allow-Methods")).isTrue();
+            assertThat(corsResponse.headers().contains("Access-Control-Allow-Headers")).isTrue();
+        }
     }
 
     @DisplayName("With an OPTIONS request on GET, POST and PUT path")


### PR DESCRIPTION
This PR adds basic CORS support to the backend server. In its current form the server basically greenlights all cross-origin requests - there is no support on a per-origin basis at current. 

- The server adds the CORS headers when it receives an incoming preflight OPTIONS request.
- A JSON response adds a wildcard origin header. 